### PR TITLE
Enhance semantic release workflow and build script execution

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -44,3 +44,4 @@ runs:
 
     - name: Run Build Script
       run: npm run build
+      shell: bash

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set Up Environment
-        uses: SP-Packages/actions/.github/actions/setup-environment@new-v1
+        uses: SP-Packages/actions/.github/actions/setup-environment@main
         with:
           DEV_DEPENDENCIES: true
 

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set Up Environment
-        uses: SP-Packages/actions/.github/actions/setup-environment@main
+        uses: SP-Packages/actions/.github/actions/setup-environment@new-v1
         with:
           DEV_DEPENDENCIES: true
 

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set Up Environment
-        uses: SP-Packages/actions/.github/actions/setup-environment@new-v1
+        uses: SP-Packages/actions/.github/actions/setup-environment@main
         with:
           DEV_DEPENDENCIES: true
 

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -11,6 +11,8 @@ on:
     secrets:
       GH_TOKEN:
         required: true
+      NPM_TOKEN:
+        required: true
 
 jobs:
   semantic-release:
@@ -25,3 +27,4 @@ jobs:
         run: npx semantic-release --dry-run=${{ inputs.DRY_RUN }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set Up Environment
-        uses: SP-Packages/actions/.github/actions/setup-environment@main
+        uses: SP-Packages/actions/.github/actions/setup-environment@new-v1
         with:
           DEV_DEPENDENCIES: true
 


### PR DESCRIPTION
Add NPM token to the semantic release workflow and specify bash as the shell for the build script execution. Update the setup-environment action to use the main branch.